### PR TITLE
Fix brackets

### DIFF
--- a/terraform/modules/sg/main.tf
+++ b/terraform/modules/sg/main.tf
@@ -89,7 +89,7 @@ resource "aws_security_group" "this" {
   dynamic "ingress" {
     #iterator = port
     for_each = {
-      for i in setproduct(var.custom_ports, var.custom_protocols, var.custom_cidr_blocks) : "${i[0]}/${i[1]}/$i[2]" => {
+      for i in setproduct(var.custom_ports, var.custom_protocols, var.custom_cidr_blocks) : "${i[0]}/${i[1]}/${i[2]}" => {
         port = i[0]
         protocol = i[1]
         cidr_block = i[2]


### PR DESCRIPTION
I have found typo - missing curly brackets inside for in security_group definition. I think they should be there.

Signed-off-by: Filip Niko <filip.niko25@gmail.com>